### PR TITLE
Add Support for Partial Quote Strings, and Fixes Comment Parsing.

### DIFF
--- a/Pdoxcl2Sharp.Test/Parse.cs
+++ b/Pdoxcl2Sharp.Test/Parse.cs
@@ -96,49 +96,61 @@ namespace Pdoxcl2Sharp.Test
         [Test]
         public void SimpleComment()
         {
-            string toParse = "#culture=michigan";
+            string toParse = "#culture=michigan\n" +
+                             "tag2 = data2";
             var data = toParse.ToStream();
 
             string actual = String.Empty;
+            string tag2 = String.Empty;
             Dictionary<string, Action<ParadoxParser>> dictionary = new Dictionary<string, Action<ParadoxParser>>
             {
-                { "culture", x => actual = x.ReadString() }
+                { "culture", x => actual = x.ReadString() },
+                { "tag2", x => tag2 = x.ReadString() }
             };
 
             ParadoxParser.Parse(data, dictionary.ParserAdapter());
             Assert.AreEqual(String.Empty, actual);
+            Assert.AreEqual("data2",tag2);
         }
 
         [Test]
         public void FollowingCommentNoSpace()
         {
-            string toParse = "tag = data#culture=michigan";
+            string toParse = "tag = data#culture=michigan\n" +
+                             "tag2 = data2";
             var data = toParse.ToStream();
 
             string actual = String.Empty;
+            string tag2 = String.Empty;
             Dictionary<string, Action<ParadoxParser>> dictionary = new Dictionary<string, Action<ParadoxParser>>
             {
-                { "culture", x => actual = x.ReadString() }
+                { "culture", x => actual = x.ReadString() },
+                { "tag2", x => tag2 = x.ReadString() }
             };
 
             ParadoxParser.Parse(data, dictionary.ParserAdapter());
             Assert.AreEqual(String.Empty, actual);
+            Assert.AreEqual("data2", tag2);
         }
 
         [Test]
         public void FollowingCommentWithSpace()
         {
-            string toParse = "tag = data #culture=michigan";
+            string toParse = "tag = data #culture=michigan\n" +
+                             "tag2 = data2";
             var data = toParse.ToStream();
 
             string actual = String.Empty;
+            string tag2 = String.Empty;
             Dictionary<string, Action<ParadoxParser>> dictionary = new Dictionary<string, Action<ParadoxParser>>
             {
-                { "culture", x => actual = x.ReadString() }
+                { "culture", x => actual = x.ReadString() },
+                { "tag2", x => tag2 = x.ReadString() }
             };
 
             ParadoxParser.Parse(data, dictionary.ParserAdapter());
             Assert.AreEqual(String.Empty, actual);
+            Assert.AreEqual("data2", tag2);
         }
 
         [Test]

--- a/Pdoxcl2Sharp/ParadoxParser.cs
+++ b/Pdoxcl2Sharp/ParadoxParser.cs
@@ -656,7 +656,9 @@ namespace Pdoxcl2Sharp
                 return SetCurrentToken(temp);
             }
 
-            if (currentToken == LexerToken.Comment)
+            // Check current character because checking the current token will cause it
+            // to skip the next tag if the comment is preceeded by a space.
+            if (currentChar == '#')
             {
                 while((currentChar = ReadNext()) != '\n' && !eof)
                     ;


### PR DESCRIPTION
Adds support for strings in the following format `"na me"_group`, and also fixes comment parsing for this usage: `tag = data#comment`.
