### PR TITLE
Increase max token size

### DIFF
--- a/src/Pdoxcl2Sharp/ParadoxParser.cs
+++ b/src/Pdoxcl2Sharp/ParadoxParser.cs
@@ -22,7 +22,7 @@ namespace Pdoxcl2Sharp
 
     public class ParadoxParser
     {
-        private const int MaxTokenSize = 256;
+        private const int MaxTokenSize = 512;
 
         private const NumberStyles SignedFloatingStyle = NumberStyles.AllowDecimalPoint | NumberStyles.AllowLeadingSign;
 


### PR DESCRIPTION
The syntax in EU4 and probably others allows custom functions where arguments can be multi line text within "", and the limit for that arguments is 512